### PR TITLE
Add webdrivers gem to manage Chromedriver

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,4 @@
 source 'https://rubygems.org'
 
 gem "eyes_selenium", "= 3.18.3"
+gem 'webdrivers', '~> 4.0', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -63,12 +63,17 @@ GEM
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.7.7)
+    webdrivers (4.6.1)
+      nokogiri (~> 1.6)
+      rubyzip (>= 1.3.0)
+      selenium-webdriver (>= 3.0, < 4.0)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   eyes_selenium (= 3.18.3)
+  webdrivers (~> 4.0)
 
 BUNDLED WITH
    2.1.4

--- a/hackathon_activity.rb
+++ b/hackathon_activity.rb
@@ -1,4 +1,5 @@
 require 'eyes_selenium'
+require 'webdrivers'
 
 APPLIFASHIONV1 = "https://demo.applitools.com/gridHackathonV1.html"
 APPLIFASHIONVDEV = "https://demo.applitools.com/tlcHackathonDev.html"

--- a/hackathon_solution.rb
+++ b/hackathon_solution.rb
@@ -1,4 +1,5 @@
 require 'eyes_selenium'
+require 'webdrivers'
 
 APPLIFASHIONV1 = "https://demo.applitools.com/gridHackathonV1.html"
 APPLIFASHIONVDEV = "https://demo.applitools.com/tlcHackathonDev.html"

--- a/simple_test_script.rb
+++ b/simple_test_script.rb
@@ -1,4 +1,5 @@
 require 'eyes_selenium'
+require 'webdrivers'
 
 OpenSSL::SSL::VERIFY_PEER = OpenSSL::SSL::VERIFY_NONE
 


### PR DESCRIPTION
This change set adds the [webdrivers gem](https://github.com/titusfortner/webdrivers) to add automatic management of the browser webdrivers, specifically Chromedriver.